### PR TITLE
Add test for SELinux modules

### DIFF
--- a/spec/selinux_module_spec.rb
+++ b/spec/selinux_module_spec.rb
@@ -1,0 +1,6 @@
+require 'spec_helper'
+
+describe selinux_module('bootloader') do
+  it { should be_installed }
+  it { should be_enabled }
+end


### PR DESCRIPTION
Tests to ensure that bootloader (a default SELinux module between Gentoo, Fedora, and Ubuntu, and thus, I assume, most others) is installed and enabled (its default state) to verify that SELinux module support in serverspec works.
