### PR TITLE
Add WinRM integration test on appveyor.

### DIFF
--- a/Gemfile.winrm
+++ b/Gemfile.winrm
@@ -1,0 +1,15 @@
+source 'https://rubygems.org'
+
+case ENV['APPVEYOR_REPO_NAME'].split("/").last
+when "specinfra"
+  gem "specinfra", path: "../../"
+  gem "serverspec", github: "serverspec/serverspec"
+when "serverspec"
+  gem "specinfra", github: "serverspec/specinfra"
+  gem "serverspec", path: "../../"
+else
+  gem "specinfra", github: "serverspec/specinfra"
+  gem "serverspec", github: "serverspec/serverspec"
+end
+
+gem 'winrm'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,57 @@
+version: "{build}"
+
+os: Windows Server 2012
+platform:
+  - x64
+
+environment:
+  bundle_gemfile: integration-test/Gemfile.winrm
+  bundler_url: https://rubygems.org/downloads/bundler-1.9.9.gem
+
+  matrix:
+    - ruby_version: "193"
+    - ruby_version: "200"
+    - ruby_version: "21"
+    - ruby_version: "22"
+
+matrix:
+  allow_failures:
+    - ruby_version: "22" # waiting for net-ssh update
+
+clone_depth: 5
+
+cache:
+  - C:\Ruby193\lib\ruby\gems\1.9.1
+  - C:\Ruby193\bin
+  - C:\Ruby200\lib\ruby\gems\2.0.0
+  - C:\Ruby200\bin
+  - C:\Ruby21\lib\ruby\gems\2.1.0
+  - C:\Ruby21\bin
+  - C:\Ruby22\lib\ruby\gems\2.2.0
+  - C:\Ruby22\bin
+
+install:
+  - git submodule update --init --recursive
+  - ps: Enable-PSRemoting -Force
+  - ps: Set-ExecutionPolicy RemoteSigned
+  - winrm quickconfig -q
+  - winrm set winrm/config/client @{TrustedHosts="*"}
+  - winrm set winrm/config/client/auth @{Basic="true"}
+  - winrm set winrm/config/service/auth @{Basic="true"}
+  - winrm set winrm/config/service @{AllowUnencrypted="true"}
+  - SET PATH=C:\Ruby%ruby_version%\bin;%PATH%
+  - echo %PATH%
+  - ruby --version
+  - gem --version
+  - appveyor DownloadFile -Url %bundler_url% -FileName bundler.gem
+  - gem install --local bundler.gem --no-ri --no-rdoc ## appveyor often stops `gem install bundler`..?
+
+build_script:
+  - ruby -rfileutils -e 'FileUtils.rm_r(File.join(Gem.dir, "cache", "bundler")) if Dir.exists?(File.join(Gem.dir, "cache", "bundler"))'
+  - bundle install --jobs 3 --retry 3
+  - net user
+  - net localgroup
+
+test_script:
+  - net user appveyor %WINDOWS_PASSWORD% # set by webui
+  - bundle exec rspec -fd --backtrace -r .\integration-test\winrm\spec_helper.rb .\integration-test\winrm

--- a/winrm/serverspec/group_spec.rb
+++ b/winrm/serverspec/group_spec.rb
@@ -1,0 +1,3 @@
+describe group("Administrators") do
+  it { should be_exist }
+end

--- a/winrm/serverspec/port_spec.rb
+++ b/winrm/serverspec/port_spec.rb
@@ -1,0 +1,3 @@
+describe port(5985) do
+  it { should be_listening }
+end

--- a/winrm/serverspec/service_spec.rb
+++ b/winrm/serverspec/service_spec.rb
@@ -1,0 +1,4 @@
+describe service("WinRM") do
+  it { should be_running }
+  it { should be_enabled }
+end

--- a/winrm/serverspec/user_spec.rb
+++ b/winrm/serverspec/user_spec.rb
@@ -1,0 +1,3 @@
+describe user("appveyor") do
+  it { should be_exist }
+end

--- a/winrm/spec_helper.rb
+++ b/winrm/spec_helper.rb
@@ -1,0 +1,13 @@
+require 'serverspec'
+require 'winrm'
+
+set :backend, :winrm
+
+user = 'appveyor'
+pass = ENV['WINDOWS_PASSWORD']
+endpoint = "http://127.0.0.1:5985/wsman"
+
+winrm = ::WinRM::WinRMWebService.new(endpoint, :ssl, :user => user, :pass => pass, :basic_auth_only => true)
+winrm.set_timeout 300 # 5 minutes max timeout for any operation
+Specinfra.configuration.winrm = winrm
+


### PR DESCRIPTION
WinRMバックエンドの結合テストを追加しました。Appveyorで実施予定です。

お試し版の様子はこちらです。
https://ci.appveyor.com/project/sawanoboly/serverspec/history

werckerと違いsubmoduleのinit,updateがまだ手動なのでlinkにはできませんでした。
いまのところこれを追加後、serverspec, specinfraに`appveyor,yml`をコピーする必要がありますので、これで問題なさそうならばそっちもPR作成します。