### PR TITLE
Avoid testing port of UDP in RHEL7 (iproute2 has a bug)

### DIFF
--- a/spec/port_spec.rb
+++ b/spec/port_spec.rb
@@ -1,5 +1,9 @@
 require 'spec_helper'
 
+def rhel7?
+  host_inventory['platform'] == 'redhat' && host_inventory['platform_version'].to_i == 7
+end
+
 describe port(22) do
   it { should be_listening }
   it { should be_listening.with('tcp') }
@@ -8,6 +12,12 @@ end
 
 describe port(53) do
   it { should be_listening }
-  it { should be_listening.with('udp') }
+
+  context 'ss in rhel7 has a bug that the netid shows "tcp" always' do
+    it 'If rhel7, skip this test', :unless => rhel7? do
+      should be_listening.with('udp')
+    end
+  end
+
   it { should be_listening.with('tcp') }
 end


### PR DESCRIPTION
`ss` command in RHEL7 has a bug that **the netid field shows "tcp" always.**

This bug exists at iproute2 v3.10.0, and is solved at v3.14.0:

> -  http://git.kernel.org/cgit/linux/kernel/git/shemminger/iproute2.git/commit/?id=77a8ca81189197e8d5e75fe19951efd0aea337d5

So, in RHEL7, it has no choice but to skip the test of UDP port...

---

AND, when this PR is merged, CI of wercker at serverspec/specinfra#445 may pass.