### PR TITLE
set < 3.0 to net-ssh version for ruby 1.x

### DIFF
--- a/Gemfile.winrm
+++ b/Gemfile.winrm
@@ -13,3 +13,7 @@ else
 end
 
 gem 'winrm'
+
+if RbConfig::CONFIG['MAJOR'] == "1"
+  gem 'net-ssh', "< 3.0"
+end


### PR DESCRIPTION
https://ci.appveyor.com/project/serverspec-windows-integration-test/specinfra/build/288/job/837hmwwfrmdyrbr6

The net-ssh 3.0.x〜 no longer works on ruby < 2.0.
This change detects ruby major version and define 2.9.x if be needed on appveyor.