### PR TITLE
set winrm version to less than 2

### DIFF
--- a/Gemfile.winrm
+++ b/Gemfile.winrm
@@ -12,7 +12,7 @@ else
   gem "serverspec", github: "mizzy/serverspec"
 end
 
-gem 'winrm'
+gem 'winrm', "< 2.0"
 
 if RbConfig::CONFIG['MAJOR'] == "1"
   gem 'net-ssh', "< 3.0"


### PR DESCRIPTION
winrmの1と2でインターフェースに互換性がないので、一旦2以下に限定。