### PR TITLE
Port to Winrm v2

### DIFF
--- a/Gemfile.winrm
+++ b/Gemfile.winrm
@@ -12,7 +12,7 @@ else
   gem "serverspec", github: "mizzy/serverspec"
 end
 
-gem 'winrm', "< 2.0"
+gem 'winrm', ">= 2.0", "< 3.0"
 
 if RbConfig::CONFIG['MAJOR'] == "1"
   gem 'net-ssh', "< 3.0"

--- a/winrm/spec_helper.rb
+++ b/winrm/spec_helper.rb
@@ -3,11 +3,10 @@ require 'winrm'
 
 set :backend, :winrm
 
-user = 'appveyor'
-pass = ENV['WINDOWS_PASSWORD']
-endpoint = "http://127.0.0.1:5985/wsman"
-
-winrm = ::WinRM::WinRMWebService.new(endpoint, :ssl, :user => user, :pass => pass, :basic_auth_only => true)
-winrm.set_timeout 300 # 5 minutes max timeout for any operation
-Specinfra.configuration.winrm = winrm
-
+opts = {
+  endpoint: 'http://127.0.0.1:5985/wsman',
+  user: 'appveyor',
+  password: ENV['WINDOWS_PASSWORD'],
+  operation_timeout: 300 # 5 minutes max timeout for any operation
+}
+Specinfra.configuration.winrm = WinRM::Connection.new(opts)


### PR DESCRIPTION
Update winrm/spec_helper to use the Winrm v2 api.

Hopefully this will fix the broken appveyor builds...