### PR TITLE
use winrm < 2.0 for ruby 1.9.3 due to support was dropped.

### DIFF
--- a/Gemfile.winrm
+++ b/Gemfile.winrm
@@ -12,8 +12,10 @@ else
   gem "serverspec", github: "mizzy/serverspec"
 end
 
-gem 'winrm', ">= 2.0", "< 3.0"
 
 if RbConfig::CONFIG['MAJOR'] == "1"
   gem 'net-ssh', "< 3.0"
+  gem 'winrm', "< 2.0"
+else
+  gem 'winrm', ">= 2.0", "< 3.0"
 end


### PR DESCRIPTION
Winrm does not test with Ruby 1.9.3, so future compatibility can not be guaranteed.