### PR TITLE
set ffi version < 1.10 when ruby < 2.2 for testing windows features on AppVeyor

### DIFF
--- a/Gemfile.winrm
+++ b/Gemfile.winrm
@@ -19,3 +19,7 @@ if RbConfig::CONFIG['MAJOR'] == "1"
 else
   gem 'winrm', ">= 2.0", "< 3.0"
 end
+
+if Gem::Version.new(RbConfig::CONFIG['RUBY_PROGRAM_VERSION']) < Gem::Version.new('2.2')
+  gem 'ffi', "< 1.10"
+end


### PR DESCRIPTION
The ffi required by winrm ended support of less than Ruby 2.2 in release 1.10.x of the other day. In order to finish testing on AppVeyor normally, we will make ffi version less than 1.10 for ruby > 2.2.

- https://ci.appveyor.com/project/serverspec-windows-integration-test/specinfra/builds/21457030

```
In Gemfile.winrm:
winrm was resolved to 2.2.3, which depends on
  gssapi was resolved to 1.2.0, which depends on
    ffi

Gem::RuntimeRequirementNotMetError: ffi requires Ruby version >= 2.2, < 2.7.dev.
The current ruby version is 2.1.0.
An error occurred while installing ffi (1.10.0), and Bundler cannot continue.
Make sure that `gem install ffi -v '1.10.0' --source 'https://rubygems.org/'`
```